### PR TITLE
Misc. bug fixes

### DIFF
--- a/examples/common.c
+++ b/examples/common.c
@@ -248,10 +248,13 @@ int cred_acquire_cb(git_credential **out,
 			}
 		}
 		if (privkey == NULL) {
-			printf("No user.identityFile found in git config\n");
+			printf("No user.identityFile found in git config.\n");
 			if ((error = ask(&privkey, "SSH Key:", 0)) < 0 ||
 					(error = ask(&password, "Password:", 1)) < 0)
 				goto out;
+			printf("Consider running,");
+			printf("    lg2 config user.identityFile\t '%s'", privkey);
+			printf("    lg2 config user.password\t '%s'", password);
 		}
 
 		// Expand path to private key

--- a/examples/common.c
+++ b/examples/common.c
@@ -245,6 +245,8 @@ int cred_acquire_cb(git_credential **out,
 				} else {
 					privkey = strdup(entry->value);
 				}
+
+				printf("SSH authentication: Using private key: %s\n", privkey);
 				error = git_config_get_entry(&entry, cfg, "user.password");
 				if (error >= 0)
 					password = strdup(entry->value);

--- a/examples/common.c
+++ b/examples/common.c
@@ -155,6 +155,14 @@ static int readline(char **out)
 		goto error;
 	}
 
+	// We encountered an EOF (line == NULL -> first
+	// getchar() was null).
+	if (line == NULL) {
+		error = -1;
+		errno = EIO; // Report generic IO error.
+		goto error;
+	}
+
 	line[length] = '\0';
 	*out = line;
 	line = NULL;
@@ -169,8 +177,8 @@ static int ask(char **out, const char *prompt, char optional)
 	printf("%s ", prompt);
 	fflush(stdout);
 
-	if (!readline(out) && !optional) {
-		fprintf(stderr, "Could not read response: %s", strerror(errno));
+	if (readline(out) <= 0 && !optional) {
+		fprintf(stderr, "Could not read response: %s\n", strerror(errno));
 		return -1;
 	}
 

--- a/examples/fetch.c
+++ b/examples/fetch.c
@@ -76,6 +76,7 @@ int lg2_fetch(git_repository *repo, int argc, char **argv)
 	fetch_opts.callbacks.sideband_progress = &progress_cb;
 	fetch_opts.callbacks.transfer_progress = transfer_progress_cb;
 	fetch_opts.callbacks.credentials = cred_acquire_cb;
+	fetch_opts.callbacks.payload = repo; // iOS addition, send repo to cb to get username/password or identityFile
 
 	/**
 	 * Perform the fetch with the configured refspecs from the


### PR DESCRIPTION
## Summary
 * Support `~` in given SSH keys.
 * Support `Ctrl+D` in readline without segfault
 * Additional logging
     * Includes a message explaining how to select an `.ssh` key.

## Notes
 * For me, `lg2` is able to find and initialize my ssh key (on Ubuntu), but seems to fail during authentication and so try to authenticate again, and again, and again...
     * I don't think my changes made this happen, but please check to make sure this works for you.