### PR TITLE
Additional options for `clone` and `commit`, additional documentation for `tag`

### DIFF
--- a/examples/add.c
+++ b/examples/add.c
@@ -170,3 +170,4 @@ static void parse_opts(const char **repo_path, struct index_options *opts, struc
 		}
 	}
 }
+

--- a/examples/clone.c
+++ b/examples/clone.c
@@ -71,14 +71,31 @@ int lg2_clone(git_repository *repo, int argc, char **argv)
 	git_repository *cloned_repo = NULL;
 	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
 	git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
-	const char *url = argv[1];
-	const char *path = argv[2];
+	char *url = argv[1];
+	char *path = NULL;
 	int error;
 
 	(void)repo; /* unused */
 
-	/* Validate args */
-	if (argc < 3) {
+	/* Parse/validate args */
+	if (argc == 2) {
+		size_t chars_from_end = 0;
+		size_t full_len = strlen(url);
+		char *c = url + full_len - 1;
+
+		for (; c >= url; --c,++chars_from_end) {
+			if (*c == '/') {
+				break;
+			}
+		}
+
+		// Determine where the name of the path should start.
+		path = url + full_len - chars_from_end;
+
+		printf("Cloning into ./%s\n", path);
+	} else if (argc == 3) {
+		path = argv[2];
+	} else {
 		printf ("USAGE: %s <url> <path>\n", argv[0]);
 		return -1;
 	}

--- a/examples/commit.c
+++ b/examples/commit.c
@@ -14,6 +14,17 @@
 
 #include "common.h"
 
+typedef struct {
+	char *message;
+	int amend_head;
+} commit_options;
+
+/** Don't write an encoding header. Assume UTF-8. */
+#define MESSAGE_ENCODING NULL
+
+/// Returns 0 on success.
+static int parse_options(commit_options *out, int argc, char **argv);
+
 /**
  * This example demonstrates the libgit2 commit APIs to roughly
  * simulate `git commit` with the commit message argument.
@@ -30,36 +41,66 @@
  */
 int lg2_commit(git_repository *repo, int argc, char **argv)
 {
-	const char *opt = argv[1];
-	const char *comment = argv[2];
+	commit_options opts;
 	int error;
 
 	git_oid commit_oid,tree_oid;
-	git_tree *tree;
-	git_index *index;
+	git_tree *tree = NULL;
+	git_index *index = NULL;
 	git_object *parent = NULL;
 	git_reference *ref = NULL;
-	git_signature *signature;
+	git_commit *old_head = NULL;
+	git_signature *signature = NULL;
 
 	/* Validate args */
-	if (argc < 3 || strcmp(opt, "-m") != 0) {
-		printf ("USAGE: %s -m <comment>\n", argv[0]);
+	if (parse_options(&opts, argc, argv)) {
+		fprintf(stderr,
+			"USAGE: %s [--amend] -m <comment>\n"
+			"       %s [--amend] --message <comment>\n"
+			"           Commit with message, <comment>.\n"
+			"           If --amend is given, replace\n"
+			"           HEAD with this commit.\n", argv[0], argv[0]);
 		return -1;
 	}
 
 	error = git_revparse_ext(&parent, &ref, repo, "HEAD");
 	if (error == GIT_ENOTFOUND) {
-		printf("HEAD not found. Creating first commit\n");
 		error = 0;
+
+		if (opts.amend_head) {
+			fprintf(stderr, "HEAD not found. Unable to amend.\n");
+			error = 1;
+			goto cleanup;
+		}
+
+		printf("HEAD not found. Creating the first commit.\n");
 	} else if (error != 0) {
 		const git_error *err = git_error_last();
 		if (err) printf("ERROR %d: %s\n", err->klass, err->message);
 		else printf("ERROR %d: no detailed info\n", error);
+
+		goto cleanup;
+	} else if (opts.amend_head) {
+		error = get_repo_head(&old_head, repo);
+		if (error) {
+			goto cleanup;
+		}
+
+		error = git_commit_amend(&commit_oid,
+				old_head,
+				"HEAD", // Make HEAD point to the new commit.
+				NULL, // Leave the author untouched
+				NULL, // Leave the committer untouched
+				MESSAGE_ENCODING,
+				opts.message,
+				NULL); // Use the same tree
+		printf("Updated HEAD.\n");
+		goto cleanup;
 	}
 
 	check_lg2(git_repository_index(&index, repo), "Could not open repository index", NULL);
-	check_lg2(git_index_write_tree(&tree_oid, index), "Could not write tree", NULL);;
-	check_lg2(git_index_write(index), "Could not write index", NULL);;
+	check_lg2(git_index_write_tree(&tree_oid, index), "Could not write tree", NULL);
+	check_lg2(git_index_write(index), "Could not write index", NULL);
 
 	check_lg2(git_tree_lookup(&tree, repo, &tree_oid), "Error looking up tree", NULL);
 
@@ -71,14 +112,56 @@ int lg2_commit(git_repository *repo, int argc, char **argv)
 		"HEAD",
 		signature,
 		signature,
-		NULL,
-		comment,
+		MESSAGE_ENCODING,
+		opts.message,
 		tree,
 		parent ? 1 : 0, parent), "Error creating commit", NULL);
 
+cleanup:
 	git_index_free(index);
 	git_signature_free(signature);
+	git_commit_free(old_head);
 	git_tree_free(tree);
 
 	return error;
 }
+
+static int parse_options(commit_options *out, int argc, char **argv)
+{
+	int i;
+
+	out->message = NULL;
+	out->amend_head = 0;
+
+	for (i = 1; i < argc; i++) {
+		char *arg = argv[i];
+		if (*arg != '-') {
+			return 1;
+		}
+
+		if (strcmp(arg, "--amend") == 0) {
+			out->amend_head = 1;
+		} else if (strcmp(arg, "-m") == 0 || strcmp(arg, "--message") == 0) {
+			i++;
+			if (i == argc) {
+				fprintf(stderr, "Missing required argument to --message.\n");
+				return 1;
+			}
+
+			out->message = argv[i];
+		} else {
+			fprintf(stderr, "Unrecognised option: %s\n", arg);
+			return 1;
+		}
+	}
+
+	if (out->message == NULL) {
+		fprintf(stderr,
+			"At present, the --message argument is required. "
+			"It was not given.\n");
+		return 1;
+	}
+
+	return 0;
+}
+

--- a/examples/common.c
+++ b/examples/common.c
@@ -332,6 +332,16 @@ out:
 	return error;
 }
 
+int repoless_cred_acquire_cb(git_credential **out,
+		const char *url,
+		const char *username_from_url,
+		unsigned int allowed_types,
+		void *ignored_payload)
+{
+	UNUSED(ignored_payload);
+	return cred_acquire_cb(out, url, username_from_url, allowed_types, NULL);
+}
+
 int certificate_confirm_cb(struct git_cert *cert,
 		int valid,
 		const char *host,

--- a/examples/common.h
+++ b/examples/common.h
@@ -142,7 +142,14 @@ extern int cred_acquire_cb(git_credential **out,
 		const char *url,
 		const char *username_from_url,
 		unsigned int allowed_types,
-		void *payload);
+		void *repo_payload);
+
+extern int repoless_cred_acquire_cb(git_credential **out,
+		const char *url,
+		const char *username_from_url,
+		unsigned int allowed_types,
+		void *ignored_payload);
+
 
 /**
  * Request that the user confirm a remote certificate before

--- a/examples/tag.c
+++ b/examples/tag.c
@@ -236,9 +236,18 @@ static void action_create_tag(tag_state *state)
 	git_signature_free(tagger);
 }
 
-static void print_usage(void)
+static void action_print_usage(tag_state *state)
 {
-	fprintf(stderr, "usage: see `git help tag`\n");
+	UNUSED(state);
+
+	fprintf(stderr, "usage: lg2 tag [-a] [-d] [-f] [-l] [-m] [-n] [<tag name>] [<target>]\n");
+	fprintf(stderr,
+		" These commands should work:\n"
+		"  - Tag name listing (`lg2 tag`)\n"
+		"  - Filtered tag listing with messages (`lg2 tag -n3 -l \"v0.1*\"`)\n"
+		"  - Lightweight tag creation (`lg2 tag test v0.18.0`)\n"
+		"  - Tag creation (`lg2 tag -a -m \"Test message\" test v0.18.0`)\n"
+		"  - Tag deletion (`lg2 tag -d test`)\n");
 	exit(1);
 }
 
@@ -256,8 +265,10 @@ static void parse_options(tag_action *action, struct tag_options *opts, int argc
 				opts->tag_name = curr;
 			else if (!opts->target)
 				opts->target = curr;
-			else
-				print_usage();
+			else {
+				*action = &action_print_usage;
+				return;
+			}
 
 			if (*action != &action_create_tag)
 				*action = &action_create_lightweight_tag;
@@ -276,6 +287,9 @@ static void parse_options(tag_action *action, struct tag_options *opts, int argc
 			*action = &action_delete_tag;
 		} else if (match_str_arg(&opts->message, &args, "-m")) {
 			*action = &action_create_tag;
+		} else {
+			*action = &action_print_usage;
+			return;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
 * Adds additional options and fixes bugs in `lg2 clone` and `lg2 commit`.
 * `lg2 tag`'s help text is no longer "see `git help tag`"

### `lg2 clone`
 * `lg2 clone <url>` is now accepted and sets the `path` (where we're cloning to) to the part of the `url` after the last `/`
     * `https://github.com/personalizedrefrigerator/AlmostMake.git` causes `path` to become `AlmostMake.git`
 * `lg2 clone` shows fetch progress

### `lg2 commit`
 * Support `--amend` option
 * Support `--message` as an alternative to `-m`