### PR TITLE
Refuse to create empty commits and other fixes

### DIFF
--- a/examples/checkout.c
+++ b/examples/checkout.c
@@ -40,7 +40,12 @@ typedef struct {
 	int progress : 1;
 	int perf : 1;
 	int create : 1;
+
+	git_strarray paths;
+	char *branch_name;
 } checkout_options;
+
+static void free_checkout_options(checkout_options *opts);
 
 static void print_usage(void)
 {
@@ -54,8 +59,11 @@ static void print_usage(void)
 	exit(1);
 }
 
-static void parse_options(const char **repo_path, checkout_options *opts, struct args_info *args)
+/// Lifetime(opts) ~ Lifetime(args->argv)
+static void parse_options(const char **repo_path, git_repository *repo, checkout_options *opts, struct args_info *args)
 {
+	int path_based = 0;
+
 	if (args->argc <= 1)
 		print_usage();
 
@@ -69,6 +77,10 @@ static void parse_options(const char **repo_path, checkout_options *opts, struct
 		int bool_arg;
 
 		if (match_arg_separator(args)) {
+			// After handling the argument separator,
+			// we have a list of paths to reset.
+			path_based = 1;
+
 			break;
 		} else if (!strcmp(curr, "-b")) {
 			opts->create = 1;
@@ -80,14 +92,52 @@ static void parse_options(const char **repo_path, checkout_options *opts, struct
 			opts->perf = bool_arg;
 		} else if (match_str_arg(repo_path, args, "--git-dir")) {
 			continue;
+		} else if (!strcmp(curr, "--help") || !strcmp(curr, "-h")) {
+			print_usage();
+		} else if (opts->branch_name == NULL) {
+			opts->branch_name = args->argv[args->pos];
 		} else {
+			fprintf(stderr, "Invalid argument: %s\n", curr);
+			print_usage();
 			break;
 		}
 	}
+
+	if (path_based) {
+		size_t paths_start = args->pos;
+		opts->paths.count = args->argc - args->pos;
+		opts->paths.strings = (char **) malloc(opts->paths.count * sizeof(char*));
+
+		for (; args->pos < args->argc; ++args->pos) {
+			char **current_out = &opts->paths.strings[args->pos - paths_start];
+			char *current_userpath = args->argv[args->pos];
+
+			/**
+			 * The user gives us paths relative to their working directory.
+			 * Convert them to paths relative to the repository's directory.
+			 */
+			get_repopath_to(current_out, current_userpath, repo);
+		}
+	} else {
+		// No paths.
+		opts->paths.strings = NULL;
+	}
+
+	if (args->pos < args->argc) {
+		opts->branch_name = args->argv[args->pos];
+	} else if (opts->branch_name == NULL) {
+		printf("Checking out HEAD...\n");
+		opts->branch_name = "HEAD";
+	}
+}
+
+static void free_checkout_options(checkout_options *opts) {
+	// get_repopath_to copies strings -- we need to free the array of paths.
+	git_strarray_dispose(&opts->paths);
 }
 
 /**
- * This function is called to report progression, ie. it's called once with
+ * This function is called to report progression, i.e. it's called once with
  * a NULL path and the number of total steps, then for each subsequent path,
  * the current completed_step value.
  */
@@ -133,6 +183,14 @@ static int perform_checkout_ref(git_repository *repo, git_annotated_commit *targ
 
 	if (opts->perf)
 		checkout_opts.perfdata_cb = print_perf_data;
+
+	if (opts->paths.count > 0) {
+		checkout_opts.paths = opts->paths;
+
+		// opts->paths shouldn't contain wildcard patterns (e.g. no *.txt globbing).
+		// Let the user's shell handle that.
+		checkout_opts.checkout_strategy |= GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
+	}
 
 	/** Grab the commit we're interested to move to */
 	err = git_commit_lookup(&target_commit, repo, git_annotated_commit_id(target));
@@ -260,49 +318,58 @@ int lg2_checkout(git_repository *repo, int argc, char **argv)
 	char *branch_name = NULL;
 
 	/** Parse our command line options */
-	parse_options(&path, &opts, &args);
-	branch_name = argv[args.pos];
+	parse_options(&path, repo, &opts, &args);
+	branch_name = opts.branch_name;
 
 	/** Make sure we're not about to checkout while something else is going on */
 	state = git_repository_state(repo);
 	if (state != GIT_REPOSITORY_STATE_NONE) {
 		fprintf(stderr, "repository is in unexpected state %d\n", state);
+
+		if (state == GIT_REPOSITORY_STATE_MERGE) {
+			fprintf(stderr, "It looks like a merge is in progress. Either "
+				"resolve the conflicts (see `lg2 status`), `lg2 add` each changed "
+				"file and commit the result, or run `lg2 reset HEAD` to stop the "
+				"merge.\n");
+		} else if (state == GIT_REPOSITORY_STATE_REBASE
+				|| state == GIT_REPOSITORY_STATE_REBASE_INTERACTIVE
+				|| state == GIT_REPOSITORY_STATE_REBASE_MERGE) {
+			fprintf(stderr, "It looks like a rebase is in progress. "
+					"If you want to cancel the rebase, run `lg2 rebase --abort`.\n");
+		}
+
 		goto cleanup;
 	}
 
-	if (match_arg_separator(&args)) {
+
+	if (opts.create) {
 		/**
-		 * Try to checkout the given path
+		 * Try to create the branch before checking it out
 		 */
 
-		fprintf(stderr, "unhandled path-based checkout\n");
-		err = 1;
-		goto cleanup;
-	} else {
-		if (opts.create) {
-			err = lg2_branch_create_from_head(repo, branch_name);
-			if (err < 0) {
-				fprintf(stderr, "failed to create %s: %s\n", args.argv[args.pos],
-						git_error_last()->message);
-				goto cleanup;
-			}
-		}
-
-		/**
-		 * Try to resolve a "refish" argument to a target libgit2 can use
-		 */
-
-		if ((err = resolve_refish(&checkout_target, repo, branch_name)) < 0 &&
-		    (err = guess_refish(&checkout_target, repo, branch_name)) < 0) {
-			fprintf(stderr, "failed to resolve %s: %s\n", branch_name,
-						git_error_last()->message);
+		err = lg2_branch_create_from_head(repo, branch_name);
+		if (err < 0) {
+			fprintf(stderr, "failed to create %s: %s\n", branch_name,
+					git_error_last()->message);
 			goto cleanup;
 		}
-		err = perform_checkout_ref(repo, checkout_target, args.argv[args.pos], &opts);
 	}
+
+	/**
+	 * Try to resolve a "refish" argument to a target libgit2 can use
+	 */
+
+	if ((err = resolve_refish(&checkout_target, repo, branch_name)) < 0 &&
+		(err = guess_refish(&checkout_target, repo, branch_name)) < 0) {
+		fprintf(stderr, "failed to resolve %s: %s\n", branch_name,
+					git_error_last()->message);
+		goto cleanup;
+	}
+	err = perform_checkout_ref(repo, checkout_target, branch_name, &opts);
 
 cleanup:
 	git_annotated_commit_free(checkout_target);
+	free_checkout_options(&opts);
 
 	return err;
 }

--- a/examples/commit.c
+++ b/examples/commit.c
@@ -19,11 +19,14 @@ typedef struct {
 	int amend_head;
 } commit_options;
 
-/** Don't write an encoding header. Assume UTF-8. */
+/** Don't write an encoding header. NULL causes libgit2 to assume UTF-8. */
 #define MESSAGE_ENCODING NULL
 
 /// Returns 0 on success.
 static int parse_options(commit_options *out, int argc, char **argv);
+
+/// Returns 1 if there are staged changes, 0 if not (or if an error occurred).
+static int are_staged_changes(int *error, git_repository *repo);
 
 /**
  * This example demonstrates the libgit2 commit APIs to roughly
@@ -81,13 +84,41 @@ int lg2_commit(git_repository *repo, int argc, char **argv)
 		else printf("ERROR %d: no detailed info\n", error);
 
 		goto cleanup;
-	} else
+	}
 
 	check_lg2(git_repository_index(&index, repo), "Could not open repository index", NULL);
 	check_lg2(git_index_write_tree(&tree_oid, index), "Could not write tree", NULL);
 	check_lg2(git_index_write(index), "Could not write index", NULL);
 
 	check_lg2(git_tree_lookup(&tree, repo, &tree_oid), "Error looking up tree", NULL);
+
+	/**
+	 * Don't create empty commits!
+	 */
+	if (!are_staged_changes(&error, repo)) {
+		if (error) {
+			fprintf(stderr, "Error determining whether there are staged changes!\n");
+			goto cleanup;
+		}
+
+		// If we're not amending, it's an error.
+		if (!opts.amend_head) {
+			fprintf(stderr, "Error: No staged changes (nothing would be in the commit!)."
+					" Refusing to commit.\n");
+			fprintf(stderr,
+				"Try running:\n"
+				" *	lg2 status\n"
+				"	    to see which changes are staged (ready to commit) and which"
+				" are unstaged.\n"
+				" *	lg2 add path/to/changed/file\n"
+				"	    to stage a file.\n"
+				"\n");
+			error = -1;
+			goto cleanup;
+		} else {
+			fprintf(stderr, "Note: There were no staged changes.\n");
+		}
+	}
 
 	error = git_signature_default(&signature, repo);
 	if (error) {
@@ -131,6 +162,29 @@ cleanup:
 	git_tree_free(tree);
 
 	return error;
+}
+
+static int are_staged_changes(int *error, git_repository *repo)
+{
+	int result = 0;
+	git_status_options status_opts;
+	git_status_list *status_list = NULL;
+
+	*error = git_status_options_init(&status_opts, GIT_STATUS_OPTIONS_VERSION);
+	if (*error) goto cleanup;
+
+	// We're only interested in changes that are staged -- those that
+	// are indexed.
+	status_opts.show = GIT_STATUS_SHOW_INDEX_ONLY;
+
+	*error = git_status_list_new(&status_list, repo, &status_opts);
+	if (*error) goto cleanup;
+
+	result = git_status_list_entrycount(status_list);
+
+cleanup:
+	git_status_list_free(status_list);
+	return result;
 }
 
 static int parse_options(commit_options *out, int argc, char **argv)

--- a/examples/lg2.c
+++ b/examples/lg2.c
@@ -11,6 +11,7 @@ struct {
 	char requires_repo;
 } commands[] = {
 	{ "add",          lg2_add,          1 },
+	{ "rm",           lg2_add,          1 },
 	{ "blame",        lg2_blame,        1 },
 	{ "branch",       lg2_branch,       1 },
 	{ "cat-file",     lg2_cat_file,     1 },

--- a/examples/lg2.c
+++ b/examples/lg2.c
@@ -50,7 +50,7 @@ static int run_command(git_command_fn fn, git_repository *repo, struct args_info
 	error = fn(repo, args.argc - args.pos, &args.argv[args.pos]);
 	if (error < 0) {
 		if (git_error_last() == NULL) {
-			fprintf(stderr, "Error has no message.\n");
+			fprintf(stderr, "Warning: An error occurred!\n");
 		} else {
 			fprintf(stderr, "Bad news:\n %s\n", git_error_last()->message);
 		}

--- a/examples/lg2.c
+++ b/examples/lg2.c
@@ -22,7 +22,10 @@ struct {
 	{ "diff",         lg2_diff,         1 },
 	{ "fetch",        lg2_fetch,        1 },
 	{ "for-each-ref", lg2_for_each_ref, 1 },
-	{ "general",      lg2_general,      0 },
+// Uncomment to test the general example. Hidden
+// because, while an important example, it doesn't
+// make sense for general use.
+//	{ "general",      lg2_general,      0 },
 	{ "index-pack",   lg2_index_pack,   1 },
 	{ "init",         lg2_init,         0 },
 	{ "log",          lg2_log,          1 },

--- a/examples/status.c
+++ b/examples/status.c
@@ -212,15 +212,15 @@ static int show_change_details_long(
 
 		if (!header && listing_index_changes) {
 			printf("# Changes to be committed:\n");
-			printf("#   (use \"git reset HEAD <file>...\" to unstage)\n");
+			printf("#   (use \"lg2 reset HEAD <file>...\" to unstage)\n");
 			printf("#\n");
 			header = 1;
 		}
 
 		if (!header && listing_workdir_changes) {
 			printf("# Changes not staged for commit:\n");
-			printf("#   (use \"git add%s <file>...\" to update what will be committed)\n", *rm_in_workdir ? "/rm" : "");
-			printf("#   (use \"git checkout -- <file>...\" to discard changes in working directory)\n");
+			printf("#   (use \"lg2 add%s <file>...\" to update what will be committed)\n", *rm_in_workdir ? "/rm" : "");
+			printf("#   (use \"lg2 checkout --force -- <file>...\" to discard changes in working directory)\n");
 			printf("#\n");
 			header = 1;
 		}
@@ -295,7 +295,7 @@ static void print_long(git_repository *repo, git_status_list *status)
 
 			if (!header) {
 				printf("# Untracked files:\n");
-				printf("#   (use \"git add <file>...\" to include in what will be committed)\n");
+				printf("#   (use \"lg2 add <file>...\" to include in what will be committed)\n");
 				printf("#\n");
 				header = 1;
 			}
@@ -318,7 +318,7 @@ static void print_long(git_repository *repo, git_status_list *status)
 
 			if (!header) {
 				printf("# Ignored files:\n");
-				printf("#   (use \"git add -f <file>...\" to include in what will be committed)\n");
+				printf("#   (use \"lg2 add -f <file>...\" to include in what will be committed)\n");
 				printf("#\n");
 				header = 1;
 			}
@@ -330,7 +330,7 @@ static void print_long(git_repository *repo, git_status_list *status)
 	}
 
 	if (!changed_in_index && changed_in_workdir)
-		printf("no changes added to commit (use \"git add\" and/or \"git commit -a\")\n");
+		printf("no changes added to commit (use \"lg2 add\" to add files to commit)\n");
 }
 
 /**


### PR DESCRIPTION
## Summary
 * Refuses to create empty commits
 * Adds `lg2 rm --cached` (a warning is printed if `--cached` isn't given -- it doesn't touch the working tree)
 * Adds `lg2 add --force`
 * Adds `lg2 checkout --force -- path1 path2` (currently only works as in actual `git` (i.e. without warning about conflicts) with `--force`)
 * Makes `lg2 status` output mention `lg2` client, rather than `git` client
---
## Details
### Refusal to create empty commits
Sample output on empty commit:
```
$ lg2 commit -m "commit: Refuse to create empty commits"
Error: No staged changes (nothing would be in the commit!). Refusing to commit.
Try running:
 *	lg2 status
	    to see which changes are staged (ready to commit) and which are unstaged.
 *	lg2 add path/to/changed/file
	    to stage a file.

Warning: An error occurred!
```

### `lg2 rm --cached`
 * `lg2 rm` (without `--cached`) would have to update the working tree
 * I would prefer to avoid `POSIX` file/directory APIs as much as possible for now :)
     * When `--cached` isn't given, instructions are given for removing the files from the working tree (with the `rm` shell command).

### `lg2 add --force`
 * Adds files even if in the `.gitignore`
 * It seems that [`git_index_update_all`](https://libgit2.org/libgit2/#HEAD/group/index/git_index_update_all) always ignores files in the `.gitignore`. `git_index_update_all` is used instead of `git_index_add_all` when `-u` is given.
     * As such, `--force` doesn't work when `-u` is given.