### PR TITLE
SSH Authentication: Add `known_hosts` check

### DIFF
--- a/examples/common.h
+++ b/examples/common.h
@@ -89,6 +89,7 @@ extern int lg2_show_index(git_repository *repo, int argc, char **argv);
 extern int lg2_stash(git_repository *repo, int argc, char **argv);
 extern int lg2_status(git_repository *repo, int argc, char **argv);
 extern int lg2_tag(git_repository *repo, int argc, char **argv);
+extern int lg2_interactive_tests(git_repository *repo, int argc, char **argv);
 
 /**
  * Check libgit2 error code, printing error to stderr on failure and

--- a/examples/lg2.c
+++ b/examples/lg2.c
@@ -41,6 +41,7 @@ struct {
 	{ "rev-list",     lg2_rev_list,     1 },
 	{ "rev-parse",    lg2_rev_parse,    1 },
 	{ "show-index",   lg2_show_index,   0 },
+	{ "self-test",    lg2_interactive_tests, 0 },
 	{ "stash",        lg2_stash,        1 },
 	{ "status",       lg2_status,       1 },
 	{ "tag",          lg2_tag,          1 },


### PR DESCRIPTION
## Summary
 * When given a remote host's certificate
   * If it requires `ssh` (and we're given `valid = 0`) check whether it's in `known_hosts`.
   * If it isn't, it asks the user whether the hostname/key pair should be added to `known_hosts`.
   * If it is in `known_hosts`, but is invalid, an error message is printed.
 * It seems that `src/transports/ssh.c` wasn't checking `$SSH_HOME/.ssh/known_hosts` for the presence of ssh keys.

## Additional notes
 * SSH passwords are currently echoed to the terminal. This has always been the case, but should also be disabled.

