### PR TITLE
Add `lg2 merge --abort`, `lg2 reset --hard`

### DIFF
--- a/examples/checkout.c
+++ b/examples/checkout.c
@@ -324,19 +324,8 @@ int lg2_checkout(git_repository *repo, int argc, char **argv)
 	/** Make sure we're not about to checkout while something else is going on */
 	state = git_repository_state(repo);
 	if (state != GIT_REPOSITORY_STATE_NONE) {
-		fprintf(stderr, "repository is in unexpected state %d\n", state);
-
-		if (state == GIT_REPOSITORY_STATE_MERGE) {
-			fprintf(stderr, "It looks like a merge is in progress. Either "
-				"resolve the conflicts (see `lg2 status`), `lg2 add` each changed "
-				"file and commit the result, or run `lg2 reset HEAD` to stop the "
-				"merge.\n");
-		} else if (state == GIT_REPOSITORY_STATE_REBASE
-				|| state == GIT_REPOSITORY_STATE_REBASE_INTERACTIVE
-				|| state == GIT_REPOSITORY_STATE_REBASE_MERGE) {
-			fprintf(stderr, "It looks like a rebase is in progress. "
-					"If you want to cancel the rebase, run `lg2 rebase --abort`.\n");
-		}
+		fprintf(stderr, "ERROR: \n");
+		print_repo_state_description(state);
 
 		goto cleanup;
 	}

--- a/examples/common.c
+++ b/examples/common.c
@@ -375,13 +375,11 @@ int cred_acquire_cb(git_credential **out,
 	char *username = NULL, *password = NULL, *privkey = NULL, *pubkey = NULL;
 	git_repository* repo = (git_repository*) payload;
 	int error = 1;
-	// iOS addition: let's get the config file
 	git_config* cfg = NULL;
 	git_config_entry *entry = NULL;
 
 	UNUSED(url);
-	/* UNUSED(payload); */
-	/* iOS addition: get username, password, identityFile from config */
+	/* Get username, password, identityFile from config */
 	if (repo != NULL)
 		error = git_repository_config(&cfg, repo);
 	else

--- a/examples/common.c
+++ b/examples/common.c
@@ -906,6 +906,26 @@ out:
 	return buf;
 }
 
+void print_repo_state_description(git_repository_state_t state) {
+	fprintf(stderr, "repository is in state %d\n", state);
+
+	if (state == GIT_REPOSITORY_STATE_MERGE) {
+		fprintf(stderr, "It looks like a merge is in progress. Either "
+			"resolve the conflicts (see `lg2 status`), `lg2 add` each changed "
+			"file and commit the result, or run `lg2 reset --hard HEAD` to stop the "
+			"merge.\n");
+	} else if (state == GIT_REPOSITORY_STATE_REBASE
+			|| state == GIT_REPOSITORY_STATE_REBASE_INTERACTIVE
+			|| state == GIT_REPOSITORY_STATE_REBASE_MERGE) {
+		fprintf(stderr, "It looks like a rebase is in progress. "
+				"If you want to cancel the rebase, run `lg2 rebase --abort`.\n");
+	} else if (state == GIT_REPOSITORY_STATE_NONE) {
+		fprintf(stderr, "This is the default state. Run lg2 rebase remote/branch"
+				" to rebase onto a branch, lg2 merge remote/branch to merge a branch"
+				" into the current.\n");
+	}
+}
+
 static int interactive_tests(void)
 {
 	char *buf = NULL;

--- a/examples/common.h
+++ b/examples/common.h
@@ -198,6 +198,12 @@ extern int certificate_confirm_cb(struct git_cert *cert,
 extern void handle_signature_create_error(int source_error);
 
 /**
+ * Prints a description of a given git_repository_state and how to return
+ * to the default state (GIT_REPOSITORY_STATE_NONE).
+ */
+extern void print_repo_state_description(git_repository_state_t state);
+
+/**
  * Repeated documentation output.
  */
 #define INSTRUCTIONS_FOR_STORING_AUTHOR_INFORMATION \

--- a/examples/fetch.c
+++ b/examples/fetch.c
@@ -78,7 +78,7 @@ int lg2_fetch(git_repository *repo, int argc, char **argv)
 
 	fetch_opts.callbacks.certificate_check = certificate_confirm_cb;
 	fetch_opts.callbacks.credentials = cred_acquire_cb;
-	fetch_opts.callbacks.payload = repo; // iOS addition, send repo to cb to get username/password or identityFile
+	fetch_opts.callbacks.payload = repo; // Send repo to cb to get username/password or identityFile
 
 	/**
 	 * Perform the fetch with the configured refspecs from the

--- a/examples/log.c
+++ b/examples/log.c
@@ -429,7 +429,7 @@ static int parse_options(
 			else
 				/** Try failed revision parse as filename. */
 				break;
-		} else if (!match_arg_separator(&args)) {
+		} else if (match_arg_separator(&args)) {
 			break;
 		}
 		else if (!strcmp(a, "--date-order"))

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -189,7 +189,7 @@ static void output_conflicts(git_index *index)
 	while ((err = git_index_conflict_next(&ancestor, &our, &their, conflicts)) == 0) {
 		fprintf(stderr, "conflict: a:%s o:%s t:%s\n",
 		        ancestor ? ancestor->path : "NULL",
-		        our->path ? our->path : "NULL",
+		        (our != NULL && our->path) ? our->path : "NULL",
 		        their->path ? their->path : "NULL");
 	}
 

--- a/examples/pull.c
+++ b/examples/pull.c
@@ -60,14 +60,13 @@ int lg2_pull(git_repository *repo, int argc, char **argv)
 	const git_indexer_progress *stats;
 	git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
 
-    /* iOS additions to have 'lg2 pull' work */
-	char* origin = "origin";
-	char* argv_merge[2];
+	char *origin = "origin";
+	char *argv_merge[2];
 
 	if (argc == 2) {
 		origin = argv[1];
 	} else if (argc > 2) {
-		fprintf(stderr, "usage: %s pull [branch]\n", argv[-1]);
+		fprintf(stderr, "usage: %s pull [remote]\n", argv[-1]);
 		return EXIT_FAILURE;
 	}
 
@@ -84,7 +83,7 @@ int lg2_pull(git_repository *repo, int argc, char **argv)
 
 	fetch_opts.callbacks.credentials = cred_acquire_cb;
 	fetch_opts.callbacks.certificate_check = certificate_confirm_cb;
-	fetch_opts.callbacks.payload = repo; // iOS addition, send repo to cb to get username/password or identityFile
+	fetch_opts.callbacks.payload = repo; // send repo to cb to get username/password or identityFile
 
 	/**
 	 * Perform the fetch with the configured refspecs from the
@@ -107,8 +106,8 @@ int lg2_pull(git_repository *repo, int argc, char **argv)
 		printf("\rReceived %u/%u objects in %" PRIuZ "bytes\n",
 			stats->indexed_objects, stats->total_objects, stats->received_bytes);
 	}
-	/* iOS: Now we merge with current directory */
 
+	/** Now we merge with current directory */
 	argv_merge[0] = "merge";
 	argv_merge[1] = "FETCH_HEAD";
 	lg2_merge(repo, 2, argv_merge);

--- a/examples/reset.c
+++ b/examples/reset.c
@@ -80,8 +80,12 @@ int lg2_reset(git_repository *repo, int argc, char **argv)
 
 		error = git_reset(repo, target, options.reset_type, &checkout_opts);
 	} else {
+		/**
+		 * If we just have a list of paths to reset, we can use `git_reset_default`.
+		 */
+
 		if (options.reset_type != GIT_RESET_SOFT) {
-			fprintf(stderr, "WARNING: --hard: Not supported for a list of paths.\n");
+			fprintf(stderr, "WARNING: Non-soft reset: Not supported for a list of paths.\n");
 		}
 
 		error = git_reset_default(repo, target, &options.paths_to_reset);


### PR DESCRIPTION
## Summary
 * Previously, aside from `rm .git/MERGE_*`, there was no way (that was aware of) to abort a merge.
 * Documentation changes:
   * `lg2 push`'s help text now correctly gives its usage as `lg2 push [upstream]`
   * Remove some source code comment references to `iOS additions` (preparation for opening a pull request to upstream)
 * Also fixes two bugs:
   * `lg2 log` didn't actually parse any arguments
   * `lg2 merge` could segfault while printing conflicts (nullptr de-ref)